### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 クライアントとして Claudeデスクトップアプリを使用する場合は Claude Pro プランのサブスクリプションが必要です。
 Windsurf や CLINE で使用することもできます。
 
+<a href="https://glama.ai/mcp/servers/dki958qnks">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/dki958qnks/badge" alt="Kintone Server MCP server" />
+</a>
+
 ## 使い方
 
 ### 1. ソースコードをダウンロードする


### PR DESCRIPTION
This PR adds a badge for the [Kintone MCP Server](https://glama.ai/mcp/servers/dki958qnks) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/dki958qnks">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/dki958qnks/badge" alt="Kintone Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.